### PR TITLE
Ligando projeto com MySql

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     compileOnly "io.micronaut:micronaut-inject-groovy"
     console "org.grails:grails-console"
     profile "org.grails.profiles:web"
+    runtime "mysql:mysql-connector-java:8.0.23"
     runtime "org.glassfish.web:el-impl:2.1.2-b03"
     runtime "com.h2database:h2"
     runtime "org.apache.tomcat:tomcat-jdbc"

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -107,8 +107,19 @@ dataSource:
 environments:
     development:
         dataSource:
-            dbCreate: create-drop
-            url: jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+            dbCreate: "update"
+            #logSql: true
+            url: "jdbc:mysql://localhost/rocketchargerMain?useSSL=false&allowPublicKeyRetrieval=true"
+            driverClassName: "com.mysql.jdbc.Driver"
+            username: "root"
+            password: "basedeelite"
+            type: "com.zaxxer.hikari.HikariDataSource"
+            properties:
+                connectionTimeout: 30000
+                idleTimeout: 600000
+                maxLifetime: 1800000
+                connectionTestQuery: "SELECT 1"
+                maximumPoolSize: 5
     test:
         dataSource:
             dbCreate: update


### PR DESCRIPTION
### Impacto

Foi aplicado as configurações no gradle e yml para conectar o projeto com banco de dados, assim ao cadastrar um customer, payer ou payment nós conseguiremos ficar com os registros salvos e fazer os devidos testes sem precisar recriar os mesmos de novo.

![bdd](https://user-images.githubusercontent.com/101358660/172377615-312a16cd-a419-4b56-9a99-b9fc1fc34202.png)

