### PR TITLE
aplicando senha de segurança

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -90,7 +90,7 @@ grails:
         host: "smtp.gmail.com"
         port: 465
         username: "rocketchargerjl@gmail.com"
-        password: "12345678abc@"
+        password: "yequusxpebflcewv"
         props:
             mail.smtp.auth: "true"
             mail.smtp.socketFactory.port: "465"


### PR DESCRIPTION
## Impacto

Foi ajustado a configuração do email conforme a documentação 
https://support.google.com/accounts/answer/185833?visit_id=637895428225961592-2962657952&p=InvalidSecondFactor&rd=1
e gerado uma nova senha de segurança diferente da senha de login onde apliquei no meu YML para conseguir fazer o envio de email novamente